### PR TITLE
Fix crates sort by relevance

### DIFF
--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -274,7 +274,11 @@ impl SyncClient {
             let mut q = url.query_pairs_mut();
             q.append_pair("page", &spec.page.to_string());
             q.append_pair("per_page", &spec.per_page.to_string());
-            q.append_pair("sort", spec.sort.to_str());
+            
+            if spec.sort != Sort::Relevance {
+                q.append_pair("sort", spec.sort.to_str());
+            }
+            
             if let Some(query) = spec.query {
                 q.append_pair("q", &query);
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ use serde_derive::*;
 use std::collections::HashMap;
 
 /// Used to specify the sort behaviour of the `Client::crates()` method.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Sort {
     /// Sort alphabetically.
     Alphabetical,


### PR DESCRIPTION
If sort of value "" is included it does not work the same way as not including the sort field at all