### PR TITLE
Allow User Fetch and Filtering Crates by User

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       run: cargo fmt --check
 
     - name: Lint
-      run: cargo clippy -D warnings --verbose
+      run: cargo clippy -- --deny warnings
 
     - name: Test
       run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.4"
 tokio = { version = "1.0.1", default-features = false, features = ["sync", "time"] }
 
 [dev-dependencies]
-tokio = "1.0.1"
+tokio = { version = "1.0.1", features = ["macros"]}
 
 [features]
 default = ["reqwest/default-tls"]

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -366,13 +366,13 @@ impl Client {
             .and_then(move |cr| c.full_crate(&cr.name, all_versions))
     }
 
-     /// Retrieves user with a username
-     pub async fn users(&self, username: &str) -> Result<User, Error> {
+    /// Retrieves user with a username
+    pub async fn users(&self, username: &str) -> Result<User, Error> {
         let url = self
             .base_url
             .join(&format!("users/{}", username))
             .unwrap();
-        self.get::<User>(&url).await
+        self.get::<UserResponse>(&url).await.and_then(|response| Ok(response.user))
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -307,7 +307,7 @@ impl Client {
             q.append_pair("per_page", &spec.per_page.to_string());
             q.append_pair("sort", spec.sort.to_str());
             if let Some(user_id) = spec.user_id {
-                q.append_pair("user_id", &user_id);
+                q.append_pair("user_id", &user_id.to_string());
             }
             if let Some(query) = spec.query {
                 q.append_pair("q", &query);
@@ -326,7 +326,7 @@ impl Client {
             sort: Sort::Alphabetical,
             per_page: 100,
             page: 1,
-            user_id: None
+            user_id: None,
         };
 
         let c = self.clone();
@@ -366,13 +366,10 @@ impl Client {
             .and_then(move |cr| c.full_crate(&cr.name, all_versions))
     }
 
-    /// Retrieves user with a username
-    pub async fn users(&self, username: &str) -> Result<User, Error> {
-        let url = self
-            .base_url
-            .join(&format!("users/{}", username))
-            .unwrap();
-        self.get::<UserResponse>(&url).await.and_then(|response| Ok(response.user))
+    /// Retrieves a user by username.
+    pub async fn user(&self, username: &str) -> Result<User, Error> {
+        let url = self.base_url.join(&format!("users/{}", username)).unwrap();
+        self.get::<UserResponse>(&url).await.map(|res| res.user)
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -306,6 +306,9 @@ impl Client {
             q.append_pair("page", &spec.page.to_string());
             q.append_pair("per_page", &spec.per_page.to_string());
             q.append_pair("sort", spec.sort.to_str());
+            if let Some(user_id) = spec.user_id {
+                q.append_pair("user_id", &user_id);
+            }
             if let Some(query) = spec.query {
                 q.append_pair("q", &query);
             }
@@ -323,6 +326,7 @@ impl Client {
             sort: Sort::Alphabetical,
             per_page: 100,
             page: 1,
+            user_id: None
         };
 
         let c = self.clone();
@@ -360,6 +364,15 @@ impl Client {
         let c = self.clone();
         self.all_crates(query)
             .and_then(move |cr| c.full_crate(&cr.name, all_versions))
+    }
+
+     /// Retrieves user with a username
+     pub async fn users(&self, username: &str) -> Result<User, Error> {
+        let url = self
+            .base_url
+            .join(&format!("users/{}", username))
+            .unwrap();
+        self.get::<User>(&url).await
     }
 }
 

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -279,6 +279,9 @@ impl SyncClient {
                 q.append_pair("sort", spec.sort.to_str());
             }
 
+            if let Some(id) = spec.user_id {
+                q.append_pair("user_id", &id.to_string());
+            }
             if let Some(query) = spec.query {
                 q.append_pair("q", &query);
             }
@@ -299,7 +302,7 @@ impl SyncClient {
                 sort: Sort::Alphabetical,
                 per_page: 100,
                 page,
-                user_id: None
+                user_id: None,
             })?;
             if !res.crates.is_empty() {
                 crates.extend(res.crates);
@@ -311,11 +314,11 @@ impl SyncClient {
         Ok(crates)
     }
 
-    /// Retrieves user with a username
-    pub fn users(&self, username: &str) -> Result<User, Error> {
+    /// Retrieves a user by username.
+    pub fn user(&self, username: &str) -> Result<User, Error> {
         let url = self.base_url.join(&format!("users/{}", username))?;
         self.get::<UserResponse>(url).map(|response| response.user)
-    } 
+    }
 }
 
 #[cfg(test)]

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -314,7 +314,7 @@ impl SyncClient {
     /// Retrieves user with a username
     pub fn users(&self, username: &str) -> Result<User, Error> {
         let url = self.base_url.join(&format!("users/{}", username))?;
-        self.get(url)
+        self.get::<UserResponse>(url).map(|response| response.user)
     } 
 }
 

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -362,4 +362,34 @@ mod test {
         let client = build_test_client();
         let _: &dyn Send = &client;
     }
+
+    #[test]
+    fn test_user_get_async() -> Result<(), Error> {
+        let client = build_test_client();
+        let user = client.user("theduke")?;
+        assert_eq!(user.login, "theduke");
+        Ok(())
+    }
+
+    #[test]
+    fn test_crates_filter_by_user_async() -> Result<(), Error> {
+        let client = build_test_client();
+
+        let user = client.user("theduke")?;
+
+        let res = client.crates(ListOptions {
+            user_id: Some(user.id),
+            per_page: 5,
+            ..Default::default()
+        })?;
+
+        assert!(!res.crates.is_empty());
+        // Ensure all found have the searched user as owner.
+        for krate in res.crates {
+            let owners = client.crate_owners(&krate.name)?;
+            assert!(owners.iter().any(|o| o.id == user.id));
+        }
+
+        Ok(())
+    }
 }

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -299,6 +299,7 @@ impl SyncClient {
                 sort: Sort::Alphabetical,
                 per_page: 100,
                 page,
+                user_id: None
             })?;
             if !res.crates.is_empty() {
                 crates.extend(res.crates);
@@ -309,6 +310,12 @@ impl SyncClient {
         }
         Ok(crates)
     }
+
+    /// Retrieves user with a username
+    pub fn users(&self, username: &str) -> Result<User, Error> {
+        let url = self.base_url.join(&format!("users/{}", username))?;
+        self.get(url)
+    } 
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,18 @@ pub struct ListOptions {
     pub query: Option<String>,
 }
 
+impl Default for ListOptions {
+    fn default() -> Self {
+        Self {
+            sort: Sort::RecentUpdates,
+            per_page: 30,
+            page: 1,
+            user_id: None,
+            query: None,
+        }
+    }
+}
+
 /// Pagination information.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Meta {

--- a/src/types.rs
+++ b/src/types.rs
@@ -325,3 +325,8 @@ pub struct FullCrate {
 
     pub versions: Vec<FullVersion>,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UserResponse {
+    pub user: User
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,7 @@ pub struct ListOptions {
     pub sort: Sort,
     pub per_page: u64,
     pub page: u64,
+    pub user_id: Option<String>,
     pub query: Option<String>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,7 +42,7 @@ pub struct ListOptions {
     pub sort: Sort,
     pub per_page: u64,
     pub page: u64,
-    pub user_id: Option<String>,
+    pub user_id: Option<u64>,
     pub query: Option<String>,
 }
 
@@ -328,5 +328,5 @@ pub struct FullCrate {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UserResponse {
-    pub user: User
+    pub user: User,
 }


### PR DESCRIPTION
- docs: README: Make rustls a subsection of Usage
- users endpoint added,  user_id field added to ListOptions
- reponse type of users endpoint is updated
- Fix and polish a user retrieval
- feat: Implement Default for ListOptions
- test: Add tests for user fetch and crate filter
- test: Use tokio::test macro for all async tests
