### PR TITLE
Replace `chrono` with `time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.9.0 - 2022-06-17
+
+This version replaces the `chrono` dependency with `time`. The current version of the `chrono` crate *(v0.4.19)* depends on an old version of the `time` crate *(v0.1.43)* that can segfault under certain conditions. Since `chrono` is currently unmaintained, it has been replaced with a version of the `time` crate *(v0.3.9)* that does not expose users to possible segfaults.
+
+### (Breaking) Changes
+
+* Error
+  - make Error #[non_exhaustive]
+  - add Error::Api variant
+  - Rename NotFound => NotFoundError
+  - Rename PermissionDenied => PermissionDeniedError
+  - Remove InvalidHeaders variant (only relevant for client construction)
+
+* Types
+  - Change type of `Crate::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `Crate::updated_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `Version::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `Version::updated_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `Category::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `Keyword::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `VersionDownloads::date` from `chrono::NaiveDate` to `time::Date`
+  - Change type of `ExtraDownloads::date` from `chrono::NaiveDate` to `time::Date`
+  - Change type of `FullVersion::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `FullVersion::updated_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `FullCrate::created_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Change type of `FullCrate::updated_at` from `chrono::DateTime<Utc>` to `time::OffsetDateTime`
+  - Remove unused `authors` field from `VersionLinks`
+
 ## 0.8.0 - 2022-01-29
 
 This version has quite a few breaking changes, 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,25 +6,31 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/theduke/crates-io-api"
 documentation = "https://docs.rs/crates_io_api"
 readme = "README.md"
-keywords = [ "crates", "api" ]
-categories = [ "web-programming", "web-programming::http-client" ]
+keywords = ["crates", "api"]
+categories = ["web-programming", "web-programming::http-client"]
 edition = "2018"
 
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
-chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
+time = { version = "0.3.9", features = ["serde-well-known"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "blocking",
+  "json",
+] }
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.32"
 url = "2.1.0"
 log = "0.4.5"
 futures = "0.3.4"
-tokio = { version = "1.0.1", default-features = false, features = ["sync", "time"] }
+tokio = { version = "1.0.1", default-features = false, features = [
+  "sync",
+  "time",
+] }
 
 [dev-dependencies]
-tokio = { version = "1.0.1", features = ["macros"]}
+tokio = { version = "1.0.1", features = ["macros"] }
 
 [features]
 default = ["reqwest/default-tls"]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Types for the data that is available via the API.
 
-use chrono::{DateTime, NaiveDate, Utc};
+use time::{OffsetDateTime, Date};
 use serde_derive::*;
 use std::collections::HashMap;
 
@@ -293,8 +293,10 @@ pub struct Crate {
     pub versions: Option<Vec<u64>>,
     pub max_version: String,
     pub links: CrateLinks,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
     pub exact_match: Option<bool>,
 }
 
@@ -316,12 +318,6 @@ pub struct CratesPage {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct VersionLinks {
-    #[deprecated(
-        since = "0.7.1",
-        note = "This field was removed from the API and will always be empty. Will be removed in 0.8.0."
-    )]
-    #[serde(default)]
-    pub authors: String,
     pub dependencies: String,
     pub version_downloads: String,
 }
@@ -332,8 +328,10 @@ pub struct VersionLinks {
 pub struct Version {
     #[serde(rename = "crate")]
     pub crate_name: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
     pub dl_path: String,
     pub downloads: u64,
     pub features: HashMap<String, Vec<String>>,
@@ -353,7 +351,8 @@ pub struct Version {
 pub struct Category {
     pub category: String,
     pub crates_cnt: u64,
-    pub created_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
     pub description: String,
     pub id: String,
     pub slug: String,
@@ -366,7 +365,8 @@ pub struct Keyword {
     pub id: String,
     pub keyword: String,
     pub crates_cnt: u64,
-    pub created_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
 }
 
 /// Full data for a crate.
@@ -398,7 +398,7 @@ pub struct Summary {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct VersionDownloads {
-    pub date: NaiveDate,
+    pub date: Date,
     pub downloads: u64,
     pub version: u64,
 }
@@ -408,7 +408,7 @@ pub struct VersionDownloads {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct ExtraDownloads {
-    pub date: NaiveDate,
+    pub date: Date,
     pub downloads: u64,
 }
 
@@ -539,8 +539,10 @@ impl ReverseDependencies {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct FullVersion {
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
     pub dl_path: String,
     pub downloads: u64,
     pub features: HashMap<String, Vec<String>>,
@@ -568,8 +570,10 @@ pub struct FullCrate {
     pub repository: Option<String>,
     pub total_downloads: u64,
     pub max_version: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
 
     pub categories: Vec<Category>,
     pub keywords: Vec<Keyword>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 //! Types for the data that is available via the API.
 
-use time::{OffsetDateTime, Date};
 use serde_derive::*;
 use std::collections::HashMap;
+use time::{Date, OffsetDateTime};
 
 /// Used to specify the sort behaviour of the `Client::crates()` method.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This PR replaces the `chrono` dependency with `time`. The current version of the `chrono` crate *(v0.4.19)* depends on an old version of the `time` crate *(v0.1.43)* that can segfault under certain conditions. Since `chrono` is currently unmaintained, it has been replaced with a version of the `time` crate *(v0.3.9)* that does not expose users to possible segfaults.

I bumped the version to 0.9 and updated the changelog as well.