### PR TITLE
add max_stable_version for crate responses

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -346,6 +346,7 @@ impl Client {
                     repository: data.repository,
                     total_downloads: data.downloads,
                     max_version: data.max_version,
+                    max_stable_version: data.max_stable_version,
                     created_at: data.created_at,
                     updated_at: data.updated_at,
                     categories: krate.categories,

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -261,6 +261,7 @@ impl SyncClient {
             repository: data.repository,
             total_downloads: data.downloads,
             max_version: data.max_version,
+            max_stable_version: data.max_stable_version,
             created_at: data.created_at,
             updated_at: data.updated_at,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -292,6 +292,7 @@ pub struct Crate {
     pub keywords: Option<Vec<String>>,
     pub versions: Option<Vec<u64>>,
     pub max_version: String,
+    pub max_stable_version: String,
     pub links: CrateLinks,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -568,6 +569,7 @@ pub struct FullCrate {
     pub repository: Option<String>,
     pub total_downloads: u64,
     pub max_version: String,
+    pub max_stable_version: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 


### PR DESCRIPTION
This is useful when creating outdated checks.