### PR TITLE
v0.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target/
 **/*.rs.bk
 Cargo.lock
 .idea
-flake.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+* Add `AsyncClient::with_http_client` constructor
+* Add `Crate::max_stable_version` field
+* Improve error reporting for JSON decoding errors
+
 ## 0.8.0 - 2022-01-29
 
 This version has quite a few breaking changes, 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ url = "2.1.0"
 log = "0.4.5"
 futures = "0.3.4"
 tokio = { version = "1.0.1", default-features = false, features = ["sync", "time"] }
+serde_path_to_error = "0.1.8"
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros"]}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flakeutils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1662096612,
+        "narHash": "sha256-R+Q8l5JuyJryRPdiIaYpO5O3A55rT+/pItBrKcy7LM4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "21de2b973f9fee595a7a1ac4693efff791245c34",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flakeutils": "flakeutils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -346,6 +346,7 @@ impl Client {
                     repository: data.repository,
                     total_downloads: data.downloads,
                     max_version: data.max_version,
+                    max_stable_version: data.max_stable_version,
                     created_at: data.created_at,
                     updated_at: data.updated_at,
                     categories: krate.categories,

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use std::collections::VecDeque;
 
 use super::Error;
+use crate::error::JsonDecodeError;
 use crate::types::*;
 
 /// Asynchronous client for the crates.io API.
@@ -156,28 +157,38 @@ impl Client {
         let time = tokio::time::Instant::now();
         let res = self.client.get(url.clone()).send().await?;
 
-        let result = match res.status() {
-            StatusCode::NOT_FOUND => Err(Error::NotFound(super::error::NotFoundError {
-                url: url.to_string(),
-            })),
-            StatusCode::FORBIDDEN => {
-                let reason = res.text().await.unwrap_or_default();
-                Err(Error::PermissionDenied(
-                    super::error::PermissionDeniedError { reason },
-                ))
-            }
-            _ if !res.status().is_success() => {
-                Err(Error::from(res.error_for_status().unwrap_err()))
-            }
-            _ => res.json::<ApiResponse<T>>().await.map_err(Error::from),
-        };
+        if !res.status().is_success() {
+            let err = match res.status() {
+                StatusCode::NOT_FOUND => Error::NotFound(super::error::NotFoundError {
+                    url: url.to_string(),
+                }),
+                StatusCode::FORBIDDEN => {
+                    let reason = res.text().await.unwrap_or_default();
+                    Error::PermissionDenied(super::error::PermissionDeniedError { reason })
+                }
+                _ => Error::from(res.error_for_status().unwrap_err()),
+            };
 
+            return Err(err);
+        }
+
+        let content = res.text().await?;
+
+        // Free up the lock
         (*lock) = Some(time);
 
-        match result? {
-            ApiResponse::Ok(t) => Ok(t),
-            ApiResponse::Err(err) => Err(Error::Api(err)),
+        // First, check for api errors.
+
+        if let Ok(errors) = serde_json::from_str::<ApiErrors>(&content) {
+            return Err(Error::Api(errors));
         }
+
+        let jd = &mut serde_json::Deserializer::from_str(&content);
+        serde_path_to_error::deserialize::<_, T>(jd).map_err(|err| {
+            Error::JsonDecode(JsonDecodeError {
+                message: format!("Could not decode JSON: {err} (path: {})", err.path()),
+            })
+        })
     }
 
     /// Retrieve a summary containing crates.io wide information.

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     NotFound(NotFoundError),
     /// No permission to access the resource.
     PermissionDenied(PermissionDeniedError),
+    /// JSON decoding of API response failed.
+    JsonDecode(JsonDecodeError),
     /// Error returned by the crates.io API directly.
     Api(crate::types::ApiErrors),
 }
@@ -36,6 +38,7 @@ impl std::fmt::Display for Error {
 
                 write!(f, "API Error ({})", inner)
             }
+            Error::JsonDecode(err) => write!(f, "Could not decode API JSON response: {err}"),
         }
     }
 }
@@ -48,6 +51,7 @@ impl std::error::Error for Error {
             Error::NotFound(_) => None,
             Error::PermissionDenied(_) => None,
             Error::Api(_) => None,
+            Error::JsonDecode(err) => Some(err),
         }
     }
 
@@ -75,6 +79,20 @@ impl From<url::ParseError> for Error {
         Error::Url(e)
     }
 }
+
+/// Error returned when the JSON returned by the API could not be decoded.
+#[derive(Debug)]
+pub struct JsonDecodeError {
+    pub(crate) message: String,
+}
+
+impl std::fmt::Display for JsonDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Could not decode JSON: {}", self.message)
+    }
+}
+
+impl std::error::Error for JsonDecodeError {}
 
 /// Error returned when a resource could not be found.
 #[derive(Debug)]

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -261,6 +261,7 @@ impl SyncClient {
             repository: data.repository,
             total_downloads: data.downloads,
             max_version: data.max_version,
+            max_stable_version: data.max_stable_version,
             created_at: data.created_at,
             updated_at: data.updated_at,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,13 +28,6 @@ impl std::fmt::Display for ApiError {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(untagged)]
-pub(crate) enum ApiResponse<T> {
-    Err(ApiErrors),
-    Ok(T),
-}
-
 /// Used to specify the sort behaviour of the `Client::crates()` method.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Sort {
@@ -292,7 +285,7 @@ pub struct Crate {
     pub keywords: Option<Vec<String>>,
     pub versions: Option<Vec<u64>>,
     pub max_version: String,
-    pub max_stable_version: String,
+    pub max_stable_version: Option<String>,
     pub links: CrateLinks,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -569,7 +562,7 @@ pub struct FullCrate {
     pub repository: Option<String>,
     pub total_downloads: u64,
     pub max_version: String,
-    pub max_stable_version: String,
+    pub max_stable_version: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -292,6 +292,7 @@ pub struct Crate {
     pub keywords: Option<Vec<String>>,
     pub versions: Option<Vec<u64>>,
     pub max_version: String,
+    pub max_stable_version: String,
     pub links: CrateLinks,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -568,6 +569,7 @@ pub struct FullCrate {
     pub repository: Option<String>,
     pub total_downloads: u64,
     pub max_version: String,
+    pub max_stable_version: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 


### PR DESCRIPTION
- refactor!: Future-proof Error (non-exhaustive)
- refactor!: Rename + document error types
- refactor!: Rename CratesResponse to CratesPage
- docs: Require docs for public items + add docs
- refactor: Add SyncClient::crate_reverse_dependencies_page
- test: Fix doctests
- build(ci): Also test Rust nightly
- build(ci): Configure dependabot updates
- test: Minor docteset changes
- docs: Prepare 0.8.0 changelog
- (cargo-release) version 0.8.0
- Deprecate Crate::license field
- add max_stable_version
- Improve error reporting for JSON decoding
- Don't ignore flake.lock
- Prepare 0.8.1 changelog
