### PR TITLE
Support alternative crate registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.9.0
+
+This version has a breaking change to support specifying alternative crate registries.
+
+### Features
+
+* Query registries other than crates-io
+
+### (Breaking) Changes
+
+* `AsyncClient` and `SyncClient` take an `Option(&Registry)`
+* Types, make field optional: User {url}
+
 ## 0.8.1
 
 * Add `AsyncClient::with_http_client` constructor
@@ -10,7 +23,7 @@
 
 ## 0.8.0 - 2022-01-29
 
-This version has quite a few breaking changes, 
+This version has quite a few breaking changes,
 mainly to clean up and future-proof the API.
 
 ### Features
@@ -95,7 +108,7 @@ mainly to clean up and future-proof the API.
   * Crate {recent_downloads, exact_match}
   * CrateResponse {versions, keywords, categories}
   * Version {crate_size, published_by}
-* Make field optional: User {kind} 
+* Make field optional: User {kind}
 * Fix getting the reverse dependencies.
   * Rearrange the received data for simpler manipulation.
   * Add 3 new types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,13 @@
 # Changelog
 
-## 0.9.0
-
-This version has a breaking change to support specifying alternative crate registries.
-
 ### Features
 
 * Query registries other than crates-io
+  - Additional `AsyncClient::build()` and `SyncClient::build()` functions.
+    For building a client for an alternative registry.
 
 ### (Breaking) Changes
 
-* `AsyncClient` and `SyncClient` take an `Option(&Registry)`
 * Types, make field optional: User {url}
 
 ## 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### (Breaking) Changes
 
+* `AsyncClient::with_http_client()` now requires the crate registry url to be specified.
 * Types, make field optional: User {url}
 
 ## 0.8.1

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -116,12 +116,36 @@ impl Client {
     /// let client = crates_io_api::AsyncClient::new(
     ///   "my_bot (help@my_bot.com)",
     ///   std::time::Duration::from_millis(1000),
-    ///   None,
     /// ).unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub fn new(
+        user_agent: &str,
+        rate_limit: std::time::Duration,
+    ) -> Result<Self, reqwest::header::InvalidHeaderValue> {
+        Self::build(user_agent, rate_limit, None)
+    }
+
+    /// Build a new client.
+    ///
+    /// Returns an [`Error`] if the given user agent is invalid.
+    /// ```rust
+    /// use crates_io_api::{AsyncClient,Registry};
+    /// # fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = crates_io_api::AsyncClient::build(
+    ///   "my_bot (help@my_bot.com)",
+    ///   std::time::Duration::from_millis(1000),
+    ///   Some(&Registry{
+    ///     url: "https://crates.my-registry.com/api/v1/".to_string(),
+    ///     name: Some("my_registry".to_string()),
+    ///     token: None,
+    ///     }),
+    /// ).unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build(
         user_agent: &str,
         rate_limit: std::time::Duration,
         registry: Option<&Registry>,
@@ -489,7 +513,6 @@ mod test {
         Client::new(
             "crates-io-api-continuous-integration (github.com/theduke/crates-io-api)",
             std::time::Duration::from_millis(1000),
-            None,
         )
         .unwrap()
     }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -162,7 +162,7 @@ impl Client {
         Ok(Self::with_http_client(client, rate_limit, base_url))
     }
 
-    /// Instantiate a new client.
+    /// Instantiate a new client, for the registry sepcified by base_url.
     ///
     /// To respect the offical [Crawler Policy](https://crates.io/policies#crawlers),
     /// you must specify both a descriptive user agent and a rate limit interval.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -157,7 +157,9 @@ impl Client {
             .build()
             .unwrap();
 
-        Ok(Self::with_http_client(client, rate_limit, registry))
+        let base_url = base_url(registry);
+
+        Ok(Self::with_http_client(client, rate_limit, base_url))
     }
 
     /// Instantiate a new client.
@@ -171,11 +173,9 @@ impl Client {
     pub fn with_http_client(
         client: HttpClient,
         rate_limit: std::time::Duration,
-        registry: Option<&Registry>,
+        base_url: &str,
     ) -> Self {
         let limiter = std::sync::Arc::new(tokio::sync::Mutex::new(None));
-
-        let base_url = base_url(registry);
 
         Self {
             rate_limit,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,8 +1,6 @@
 //! Helper functions for querying crate registries
-//!
-//!
-use crate::types::*;
 
+use crate::types::*;
 use reqwest::header;
 use std::env;
 
@@ -20,20 +18,18 @@ pub fn setup_headers(
     match &registry {
         Some(registry) => match &registry.name {
             Some(name) => {
-                match env::var(format!("CARGO_REGISTRIES_{}_TOKEN", name.to_uppercase())) {
-                    Ok(foo) => {
-                        headers.insert(header::AUTHORIZATION, header::HeaderValue::from_str(&foo)?);
-                        ()
-                    }
-                    _ => (),
-                }
-            }
-            None => match &registry.token {
-                Some(token) => {
+                if let Ok(token) =
+                    env::var(format!("CARGO_REGISTRIES_{}_TOKEN", name.to_uppercase()))
+                {
                     headers.insert(
                         header::AUTHORIZATION,
                         header::HeaderValue::from_str(&token)?,
                     );
+                }
+            }
+            None => match &registry.token {
+                Some(token) => {
+                    headers.insert(header::AUTHORIZATION, header::HeaderValue::from_str(token)?);
                 }
                 None => (),
             },

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,139 @@
+//! Helper functions for querying crate registries
+//!
+//!
+use crate::{error::Error, types::*};
+
+use reqwest::header;
+use std::env;
+
+/// Setup the headers for a sync or async request
+pub fn setup_headers(
+    user_agent: &str,
+    registry: Option<&Registry>,
+) -> Result<header::HeaderMap, header::InvalidHeaderValue> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::USER_AGENT,
+        header::HeaderValue::from_str(user_agent)?,
+    );
+
+    if registry.is_some() {
+        match &registry.unwrap().name {
+            Some(name) => {
+                match env::var(format!("CARGO_REGISTRIES_{}_TOKEN", name.to_uppercase())) {
+                    Ok(foo) => {
+                        headers.insert(header::AUTHORIZATION, header::HeaderValue::from_str(&foo)?);
+                        ()
+                    }
+                    _ => (),
+                }
+            }
+            None => match &registry.unwrap().token {
+                Some(token) => {
+                    headers.insert(
+                        header::AUTHORIZATION,
+                        header::HeaderValue::from_str(&token)?,
+                    );
+                }
+                None => (),
+            },
+        }
+    }
+    Ok(headers)
+}
+
+/// Determine the url of the crate registry being queried.
+pub fn base_url(registry: Option<&Registry>) -> &str {
+    match registry {
+        Some(reg) => reg.url.as_str(),
+        None => "https://crates.io/api/v1/",
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_base_url_default() -> Result<(), Error> {
+        assert_eq!(base_url(None), "https://crates.io/api/v1/");
+        Ok(())
+    }
+
+    #[test]
+    fn test_base_url_private() -> Result<(), Error> {
+        let reg = &Registry {
+            url: "https://crates.foobar.com/api/v1/".to_string(),
+            name: None,
+            token: None,
+        };
+        assert_eq!(base_url(Some(reg)), "https://crates.foobar.com/api/v1/");
+        Ok(())
+    }
+
+    #[test]
+    fn test_crates_io_headers() -> Result<(), Error> {
+        let reg = None;
+        let user_agent = "crates-io-api-continuous-integration (github.com/theduke/crates-io-api)";
+        let headers = setup_headers(user_agent, reg).unwrap();
+
+        let mut exp_headers = header::HeaderMap::new();
+        exp_headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_str(user_agent).unwrap(),
+        );
+
+        assert_eq!(headers, exp_headers);
+        Ok(())
+    }
+
+    #[test]
+    fn test_private_registry_name_headers() -> Result<(), Error> {
+        let reg = &Registry {
+            url: "https://crates.foobar.com/api/v1/".to_string(),
+            name: Some("foobar".to_string()),
+            token: None,
+        };
+        env::set_var("CARGO_REGISTRIES_FOOBAR_TOKEN", "baz");
+        let user_agent = "crates-io-api-continuous-integration (github.com/theduke/crates-io-api)";
+        let headers = setup_headers(user_agent, Some(reg)).unwrap();
+
+        let mut exp_headers = header::HeaderMap::new();
+        exp_headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_str(user_agent).unwrap(),
+        );
+        exp_headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_str("baz").unwrap(),
+        );
+
+        assert_eq!(headers, exp_headers);
+        Ok(())
+    }
+
+    #[test]
+    fn test_private_registry_token_headers() -> Result<(), Error> {
+        let reg = &Registry {
+            url: "https://crates.foobar.com/api/v1/".to_string(),
+            name: None,
+            token: Some("foobar".to_string()),
+        };
+        env::set_var("CARGO_REGISTRIES_FOOBAR_TOKEN", "baz");
+        let user_agent = "crates-io-api-continuous-integration (github.com/theduke/crates-io-api)";
+        let headers = setup_headers(user_agent, Some(reg)).unwrap();
+
+        let mut exp_headers = header::HeaderMap::new();
+        exp_headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_str(user_agent).unwrap(),
+        );
+        exp_headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_str("foobar").unwrap(),
+        );
+
+        assert_eq!(headers, exp_headers);
+        Ok(())
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,7 +1,7 @@
 //! Helper functions for querying crate registries
 //!
 //!
-use crate::{error::Error, types::*};
+use crate::types::*;
 
 use reqwest::header;
 use std::env;
@@ -17,8 +17,8 @@ pub fn setup_headers(
         header::HeaderValue::from_str(user_agent)?,
     );
 
-    if registry.is_some() {
-        match &registry.unwrap().name {
+    match &registry {
+        Some(registry) => match &registry.name {
             Some(name) => {
                 match env::var(format!("CARGO_REGISTRIES_{}_TOKEN", name.to_uppercase())) {
                     Ok(foo) => {
@@ -28,7 +28,7 @@ pub fn setup_headers(
                     _ => (),
                 }
             }
-            None => match &registry.unwrap().token {
+            None => match &registry.token {
                 Some(token) => {
                     headers.insert(
                         header::AUTHORIZATION,
@@ -37,8 +37,10 @@ pub fn setup_headers(
                 }
                 None => (),
             },
-        }
+        },
+        None => (),
     }
+
     Ok(headers)
 }
 
@@ -53,6 +55,7 @@ pub fn base_url(registry: Option<&Registry>) -> &str {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::Error;
 
     #[test]
     fn test_base_url_default() -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!     let client = SyncClient::new(
 //!          "my-user-agent (my-contact@domain.com)",
 //!          std::time::Duration::from_millis(1000),
+//!          None,
 //!     ).unwrap();
 //!     // Retrieve summary data.
 //!     let summary = client.summary()?;
@@ -40,18 +41,34 @@
 //!     Ok(())
 //! }
 //! ```
+//! Instantiate a client for a private registry with environment variable authentication
+//!
+//! ```rust
+//! use crates_io_api::{SyncClient,Registry};
+//! let client = SyncClient::new(
+//!          "my-user-agent (my-contact@domain.com)",
+//!          std::time::Duration::from_millis(1000),
+//!          Some(&Registry{
+//!             url: "https://crates.my-registry.com/api/v1/".to_string(),
+//!             name: Some("my_registry".to_string()),
+//!             token: None,
+//!             }),
+//!     ).unwrap();
+//! ```
 
 #![recursion_limit = "128"]
 #![deny(missing_docs)]
 
 mod async_client;
 mod error;
+mod helper;
 mod sync_client;
 mod types;
 
 pub use crate::{
     async_client::Client as AsyncClient,
     error::{Error, NotFoundError, PermissionDeniedError},
+    helper::*,
     sync_client::SyncClient,
     types::*,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //!     let client = SyncClient::new(
 //!          "my-user-agent (my-contact@domain.com)",
 //!          std::time::Duration::from_millis(1000),
-//!          None,
 //!     ).unwrap();
 //!     // Retrieve summary data.
 //!     let summary = client.summary()?;
@@ -48,11 +47,6 @@
 //! let client = SyncClient::new(
 //!          "my-user-agent (my-contact@domain.com)",
 //!          std::time::Duration::from_millis(1000),
-//!          Some(&Registry{
-//!             url: "https://crates.my-registry.com/api/v1/".to_string(),
-//!             name: Some("my_registry".to_string()),
-//!             token: None,
-//!             }),
 //!     ).unwrap();
 //! ```
 

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -33,12 +33,33 @@ impl SyncClient {
     /// let client = crates_io_api::AsyncClient::new(
     ///   "my_bot (help@my_bot.com)",
     ///   std::time::Duration::from_millis(1000),
-    ///   None,
     /// ).unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub fn new(
+        user_agent: &str,
+        rate_limit: std::time::Duration,
+    ) -> Result<Self, reqwest::header::InvalidHeaderValue> {
+        Self::build(user_agent, rate_limit, None)
+    }
+
+    /// ```rust
+    /// use crates_io_api::{SyncClient,Registry};
+    /// # fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = crates_io_api::SyncClient::build(
+    ///   "my_bot (help@my_bot.com)",
+    ///   std::time::Duration::from_millis(1000),
+    ///   Some(&Registry{
+    ///     url: "https://crates.my-registry.com/api/v1/".to_string(),
+    ///     name: Some("my_registry".to_string()),
+    ///     token: None,
+    ///     }),
+    ///  ).unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build(
         user_agent: &str,
         rate_limit: std::time::Duration,
         registry: Option<&Registry>,
@@ -301,7 +322,6 @@ impl SyncClient {
     /// # let client = SyncClient::new(
     /// #     "my-bot-name (my-contact@domain.com)",
     /// #     std::time::Duration::from_millis(1000),
-    /// #     None,
     /// # ).unwrap();
     /// let q = CratesQuery::builder()
     ///   .sort(Sort::Alphabetical)
@@ -334,7 +354,6 @@ mod test {
         SyncClient::new(
             "crates-io-api-ci (github.com/theduke/crates-io-api)",
             std::time::Duration::from_millis(1000),
-            None,
         )
         .unwrap()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,16 @@ use chrono::{DateTime, NaiveDate, Utc};
 use serde_derive::*;
 use std::collections::HashMap;
 
+/// Used to specify the registry being queried by either client.
+pub struct Registry {
+    /// Url of the registry
+    pub url: String,
+    /// Name of the registry
+    pub name: Option<String>,
+    /// Token used to authenticate registry requests.
+    pub token: Option<String>,
+}
+
 /// Used to specify the sort behaviour of the `Client::crates()` method.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ApiErrors {
@@ -432,7 +442,7 @@ pub struct User {
     pub kind: Option<String>,
     pub login: String,
     pub name: Option<String>,
-    pub url: String,
+    pub url: Option<String>,
 }
 
 /// Additional crate author metadata.


### PR DESCRIPTION
Implementing #57. 

Currently, this is a breaking change for users of `AsyncClient::with_http_client()` and a change to `types::User::url`. 

@theduke, is making this a breaking change acceptable and are you happy with the API changes I am proposing in this PR? 

I've added support for authenticating via a token with an alternative crate registry. 