### PR TITLE
Add `recent_downloads` field to `FullCrate`

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -368,6 +368,7 @@ impl Client {
                     homepage: data.homepage,
                     repository: data.repository,
                     total_downloads: data.downloads,
+                    recent_downloads: data.recent_downloads,
                     max_version: data.max_version,
                     max_stable_version: data.max_stable_version,
                     created_at: data.created_at,

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -270,6 +270,7 @@ impl SyncClient {
             homepage: data.homepage,
             repository: data.repository,
             total_downloads: data.downloads,
+            recent_downloads: data.recent_downloads,
             max_version: data.max_version,
             max_stable_version: data.max_stable_version,
             created_at: data.created_at,

--- a/src/types.rs
+++ b/src/types.rs
@@ -562,6 +562,7 @@ pub struct FullCrate {
     pub homepage: Option<String>,
     pub repository: Option<String>,
     pub total_downloads: u64,
+    pub recent_downloads: Option<u64>,
     pub max_version: String,
     pub max_stable_version: Option<String>,
     pub created_at: DateTime<Utc>,


### PR DESCRIPTION
Fixes #62 

This turned out to be a very simple fix. I don't know if there is an ordering requirement on the fields of structs, so I just added it where I felt it made sense.