### PR TITLE
Make `Authors` derive `Debug, Clone` and serialization.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -450,6 +450,7 @@ pub(crate) struct AuthorsResponse {
 }
 
 /// Crate author names.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct Authors {
     pub names: Vec<String>,


### PR DESCRIPTION
All the other similar types seem to derive those traits, but not this one. It seems like it might have been an accidental omission.