### PR TITLE
add string representation of Sort::Relevance

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -49,7 +49,7 @@ impl Sort {
     pub(crate) fn to_str(&self) -> &str {
         match self {
             Self::Alphabetical => "alpha",
-            Self::Relevance => "",
+            Self::Relevance => "relevance",
             Self::Downloads => "downloads",
             Self::RecentDownloads => "recent-downloads",
             Self::RecentUpdates => "recent-updates",


### PR DESCRIPTION
The current empty string provided by `Sort::Relevance.to_str()` results in inaccurate results. For example:
```sh
$ curl -A 'crates-io-api' 'https://crates.io/api/v1/crates?page=1&per_page=3&sort=&q=tokio' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2572  100  2572    0     0  14591      0 --:--:-- --:--:-- --:--:-- 14953
{
  "crates": [
    {
      "badges": [],
      "categories": null,
      "created_at": "2016-07-01T20:39:07.497766+00:00",
      "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O\nbacked applications.\n",
      "documentation": null,
      "downloads": 103432336,
      "exact_match": true,
      "homepage": "https://tokio.rs",
      "id": "tokio",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/tokio/owner_team",
        "owner_user": "/api/v1/crates/tokio/owner_user",
        "owners": "/api/v1/crates/tokio/owners",
        "reverse_dependencies": "/api/v1/crates/tokio/reverse_dependencies",
        "version_downloads": "/api/v1/crates/tokio/downloads",
        "versions": "/api/v1/crates/tokio/versions"
      },
      "max_stable_version": "1.28.2",
      "max_version": "1.28.2",
      "name": "tokio",
      "newest_version": "1.28.2",
      "recent_downloads": 14214868,
      "repository": "https://github.com/tokio-rs/tokio",
      "updated_at": "2023-05-27T21:19:40.446763+00:00",
      "versions": null
    },
    {
      "badges": [],
      "categories": null,
      "created_at": "2018-06-01T23:51:51.130358+00:00",
      "description": "A native, asynchronous Apple push notification client",
      "documentation": "https://docs.rs/a2",
      "downloads": 32149,
      "exact_match": false,
      "homepage": "https://github.com/walletconnect/a2",
      "id": "a2",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/a2/owner_team",
        "owner_user": "/api/v1/crates/a2/owner_user",
        "owners": "/api/v1/crates/a2/owners",
        "reverse_dependencies": "/api/v1/crates/a2/reverse_dependencies",
        "version_downloads": "/api/v1/crates/a2/downloads",
        "versions": "/api/v1/crates/a2/versions"
      },
      "max_stable_version": "0.7.1",
      "max_version": "0.7.1",
      "name": "a2",
      "newest_version": "0.7.1",
      "recent_downloads": 5386,
      "repository": "https://github.com/walletconnect/a2.git",
      "updated_at": "2023-06-05T19:35:18.195967+00:00",
      "versions": null
    },
    {
      "badges": [],
      "categories": null,
      "created_at": "2020-10-25T07:00:31.673939+00:00",
      "description": "Asynchronous, zero-allocation HTTP client that is agnostic to choice of executor",
      "documentation": null,
      "downloads": 282,
      "exact_match": false,
      "homepage": null,
      "id": "aahc",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/aahc/owner_team",
        "owner_user": "/api/v1/crates/aahc/owner_user",
        "owners": "/api/v1/crates/aahc/owners",
        "reverse_dependencies": "/api/v1/crates/aahc/reverse_dependencies",
        "version_downloads": "/api/v1/crates/aahc/downloads",
        "versions": "/api/v1/crates/aahc/versions"
      },
      "max_stable_version": "0.1.0",
      "max_version": "0.1.0",
      "name": "aahc",
      "newest_version": "0.1.0",
      "recent_downloads": 43,
      "repository": "https://gitlab.com/Hawk777/aahc",
      "updated_at": "2020-10-25T07:00:31.673939+00:00",
      "versions": null
    }
  ],
  "meta": {
    "next_page": "?page=2&per_page=3&sort=&q=tokio",
    "prev_page": null,
    "total": 4278
  }
}

$ curl -A 'crates-io-api' 'https://crates.io/api/v1/crates?page=1&per_page=3&sort=relevance&q=tokio' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2864  100  2864    0     0   2047      0  0:00:01  0:00:01 --:--:--  2051
{
  "crates": [
    {
      "badges": [],
      "categories": null,
      "created_at": "2016-07-01T20:39:07.497766+00:00",
      "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O\nbacked applications.\n",
      "documentation": null,
      "downloads": 103432336,
      "exact_match": true,
      "homepage": "https://tokio.rs",
      "id": "tokio",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/tokio/owner_team",
        "owner_user": "/api/v1/crates/tokio/owner_user",
        "owners": "/api/v1/crates/tokio/owners",
        "reverse_dependencies": "/api/v1/crates/tokio/reverse_dependencies",
        "version_downloads": "/api/v1/crates/tokio/downloads",
        "versions": "/api/v1/crates/tokio/versions"
      },
      "max_stable_version": "1.28.2",
      "max_version": "1.28.2",
      "name": "tokio",
      "newest_version": "1.28.2",
      "recent_downloads": 14214868,
      "repository": "https://github.com/tokio-rs/tokio",
      "updated_at": "2023-05-27T21:19:40.446763+00:00",
      "versions": null
    },
    {
      "badges": [],
      "categories": null,
      "created_at": "2021-12-16T23:44:58.414893+00:00",
      "description": "A `tracing-subscriber::Layer` for collecting Tokio console telemetry.\n",
      "documentation": null,
      "downloads": 2047568,
      "exact_match": false,
      "homepage": "https://github.com/tokio-rs/console/blob/main/console-subscriber",
      "id": "console-subscriber",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/console-subscriber/owner_team",
        "owner_user": "/api/v1/crates/console-subscriber/owner_user",
        "owners": "/api/v1/crates/console-subscriber/owners",
        "reverse_dependencies": "/api/v1/crates/console-subscriber/reverse_dependencies",
        "version_downloads": "/api/v1/crates/console-subscriber/downloads",
        "versions": "/api/v1/crates/console-subscriber/versions"
      },
      "max_stable_version": "0.1.9",
      "max_version": "0.1.9",
      "name": "console-subscriber",
      "newest_version": "0.1.9",
      "recent_downloads": 655339,
      "repository": "https://github.com/tokio-rs/console/",
      "updated_at": "2023-05-09T22:44:32.148858+00:00",
      "versions": null
    },
    {
      "badges": [],
      "categories": null,
      "created_at": "2021-02-13T07:18:52.649916+00:00",
      "description": "PyO3 utilities for Python's Asyncio library",
      "documentation": "https://docs.rs/crate/pyo3-asyncio/",
      "downloads": 371492,
      "exact_match": false,
      "homepage": "https://github.com/awestlake87/pyo3-asyncio",
      "id": "pyo3-asyncio",
      "keywords": null,
      "links": {
        "owner_team": "/api/v1/crates/pyo3-asyncio/owner_team",
        "owner_user": "/api/v1/crates/pyo3-asyncio/owner_user",
        "owners": "/api/v1/crates/pyo3-asyncio/owners",
        "reverse_dependencies": "/api/v1/crates/pyo3-asyncio/reverse_dependencies",
        "version_downloads": "/api/v1/crates/pyo3-asyncio/downloads",
        "versions": "/api/v1/crates/pyo3-asyncio/versions"
      },
      "max_stable_version": "0.18.0",
      "max_version": "0.18.0",
      "name": "pyo3-asyncio",
      "newest_version": "0.18.0",
      "recent_downloads": 123790,
      "repository": "https://github.com/awestlake87/pyo3-asyncio",
      "updated_at": "2023-02-02T02:14:49.497724+00:00",
      "versions": null
    }
  ],
  "meta": {
    "next_page": "?page=2&per_page=3&sort=relevance&q=tokio",
    "prev_page": null,
    "total": 4278
  }
}
```

You can compare these results with searching crates.io using the default ("relevance") sorting: https://crates.io/search?q=tokio