### PR TITLE
Make FullVersion a superset of Version

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -310,24 +310,8 @@ impl Client {
     async fn full_version(&self, version: Version) -> Result<FullVersion, Error> {
         let authors_fut = self.crate_authors(&version.crate_name, &version.num);
         let deps_fut = self.crate_dependencies(&version.crate_name, &version.num);
-
-        try_join!(authors_fut, deps_fut).map(|(authors, deps)| FullVersion {
-            created_at: version.created_at,
-            updated_at: version.updated_at,
-            dl_path: version.dl_path,
-            downloads: version.downloads,
-            features: version.features,
-            id: version.id,
-            num: version.num,
-            yanked: version.yanked,
-            license: version.license,
-            links: version.links,
-            readme_path: version.readme_path,
-            rust_version: version.rust_version,
-
-            author_names: authors.names,
-            dependencies: deps,
-        })
+        try_join!(authors_fut, deps_fut)
+            .map(|(authors, deps)| FullVersion::from_parts(version, authors, deps))
     }
 
     /// Retrieve all available information for a crate, including download

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -323,6 +323,7 @@ impl Client {
             license: version.license,
             links: version.links,
             readme_path: version.readme_path,
+            rust_version: version.rust_version,
 
             author_names: authors.names,
             dependencies: deps,

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -208,25 +208,7 @@ impl SyncClient {
     fn full_version(&self, version: Version) -> Result<FullVersion, Error> {
         let authors = self.crate_authors(&version.crate_name, &version.num)?;
         let deps = self.crate_dependencies(&version.crate_name, &version.num)?;
-
-        let v = FullVersion {
-            created_at: version.created_at,
-            updated_at: version.updated_at,
-            dl_path: version.dl_path,
-            downloads: version.downloads,
-            features: version.features,
-            id: version.id,
-            num: version.num,
-            yanked: version.yanked,
-            license: version.license,
-            links: version.links,
-            readme_path: version.readme_path,
-            rust_version: version.rust_version,
-
-            author_names: authors.names,
-            dependencies: deps,
-        };
-        Ok(v)
+        Ok(FullVersion::from_parts(version, authors, deps))
     }
 
     /// Retrieve all available information for a crate, including download

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -221,6 +221,7 @@ impl SyncClient {
             license: version.license,
             links: version.links,
             readme_path: version.readme_path,
+            rust_version: version.rust_version,
 
             author_names: authors.names,
             dependencies: deps,

--- a/src/types.rs
+++ b/src/types.rs
@@ -566,6 +566,7 @@ pub struct FullVersion {
     pub license: Option<String>,
     pub readme_path: Option<String>,
     pub links: VersionLinks,
+    pub rust_version: Option<String>,
 
     pub author_names: Vec<String>,
     pub dependencies: Vec<Dependency>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -572,6 +572,29 @@ pub struct FullVersion {
     pub dependencies: Vec<Dependency>,
 }
 
+impl FullVersion {
+    /// Creates a [`FullVersion`] from a [`Version`], author names, and dependencies.
+    pub fn from_parts(version: Version, authors: Authors, dependencies: Vec<Dependency>) -> Self {
+        FullVersion {
+            created_at: version.created_at,
+            updated_at: version.updated_at,
+            dl_path: version.dl_path,
+            downloads: version.downloads,
+            features: version.features,
+            id: version.id,
+            num: version.num,
+            yanked: version.yanked,
+            license: version.license,
+            links: version.links,
+            readme_path: version.readme_path,
+            rust_version: version.rust_version,
+
+            author_names: authors.names,
+            dependencies,
+        }
+    }
+}
+
 /// Complete information for a crate.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,7 +71,7 @@ pub struct CratesQuery {
     pub(crate) page: u64,
     pub(crate) user_id: Option<u64>,
     /// Crates.io category name.
-    /// See https://crates.io/categories
+    /// See <https://crates.io/categories>
     /// NOTE: requires lower-case dash-separated categories, not the pretty
     /// titles visible in the listing linked above.
     pub(crate) category: Option<String>,
@@ -219,7 +219,7 @@ impl CratesQueryBuilder {
     }
 
     /// Crates.io category name.
-    /// See https://crates.io/categories
+    /// See <https://crates.io/categories>
     /// NOTE: requires lower-case dash-separated categories, not the pretty
     /// titles visible in the listing linked above.
     #[must_use]

--- a/src/types.rs
+++ b/src/types.rs
@@ -555,6 +555,8 @@ impl ReverseDependencies {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(missing_docs)]
 pub struct FullVersion {
+    #[serde(rename = "crate")]
+    pub crate_name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub dl_path: String,
@@ -566,7 +568,11 @@ pub struct FullVersion {
     pub license: Option<String>,
     pub readme_path: Option<String>,
     pub links: VersionLinks,
+    pub crate_size: Option<u64>,
+    pub published_by: Option<User>,
     pub rust_version: Option<String>,
+    #[serde(default)]
+    pub audit_actions: Vec<AuditAction>,
 
     pub author_names: Vec<String>,
     pub dependencies: Vec<Dependency>,
@@ -576,6 +582,7 @@ impl FullVersion {
     /// Creates a [`FullVersion`] from a [`Version`], author names, and dependencies.
     pub fn from_parts(version: Version, authors: Authors, dependencies: Vec<Dependency>) -> Self {
         FullVersion {
+            crate_name: version.crate_name,
             created_at: version.created_at,
             updated_at: version.updated_at,
             dl_path: version.dl_path,
@@ -587,7 +594,10 @@ impl FullVersion {
             license: version.license,
             links: version.links,
             readme_path: version.readme_path,
+            crate_size: version.crate_size,
+            published_by: version.published_by,
             rust_version: version.rust_version,
+            audit_actions: version.audit_actions,
 
             author_names: authors.names,
             dependencies,


### PR DESCRIPTION
Thank you for this awesome crate! While working on some MSRV checks on top of it, I was in the need of having `rust_version` also available in `FullVersion`. At the end I went a bit further and this PR

* Adds `rust_version` to `FullVersion`
* Also adds the remaining fields from `Version` into `FullVersion` as the naming suggests the latter being a superset of the former to me
* Factors out the conversion from `Version` to `FullVersion` into a shared implementation of `From` for not needing to keep the details in sync in both clients manually
* Cleans up the markup of two links in the docs (pointed out by `rustdoc`