### PR TITLE
chore: update reqwest to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.9.0"
 
 [dependencies]
 chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.32"

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -91,7 +91,7 @@ impl futures::stream::Stream for CrateStream {
         assert!(matches!(f.poll_unpin(cx), std::task::Poll::Pending));
         inner.next_page_fetch = Some(f);
 
-        cx.waker().clone().wake();
+        cx.waker().wake_by_ref();
 
         std::task::Poll::Pending
     }


### PR DESCRIPTION
The change should be trivial. However, as `crates.io` seems to be down right now, I expect the CI will fail with a timeout error.