### PR TITLE
Fix `SyncClient` code example

### DIFF
--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -29,7 +29,7 @@ impl SyncClient {
     ///
     /// ```rust
     /// # fn f() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = crates_io_api::AsyncClient::new(
+    /// let client = crates_io_api::SyncClient::new(
     ///   "my_bot (help@my_bot.com)",
     ///   std::time::Duration::from_millis(1000),
     /// ).unwrap();


### PR DESCRIPTION
Very small PR, I noticed the code sample in the `SyncClient` was using the `AsyncClient`. Probably a copy-and-paste error so I changed it to use the `SyncClient` 