### PR TITLE
make crate wasm compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = [ "crates", "api" ]
 categories = [ "web-programming", "web-programming::http-client" ]
 edition = "2018"
+resolver = "2"
 
 version = "0.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ edition = "2018"
 version = "0.11.0"
 
 [dependencies]
-chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
-serde = "1.0.79"
-serde_derive = "1.0.79"
-serde_json = "1.0.32"
-url = "2.1.0"
-futures = "0.3.4"
-tokio = { version = "1.0.1", default-features = false, features = ["sync", "time"] }
-serde_path_to_error = "0.1.8"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+url = "2.5"
+futures = "0.3"
+tokio = { version = "1.43", default-features = false, features = ["sync", "time"] }
+serde_path_to_error = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.0.1", features = ["macros"]}
+tokio = { version = "1.43", features = ["macros"]}
 
 [features]
 default = ["reqwest/default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,14 @@ serde_derive = "1.0"
 serde_json = "1.0"
 url = "2.5"
 futures = "0.3"
-tokio = { version = "1.43", default-features = false, features = ["sync", "time"] }
+tokio = { version = "1.43", default-features = false, features = ["sync", "time"], optional = true }
 serde_path_to_error = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.43", features = ["macros"]}
+tokio = { version = "1.43", features = ["macros"] }
 
 [features]
-default = ["reqwest/default-tls"]
+default = ["reqwest/default-tls", "sync", "async"]
 rustls = ["reqwest/rustls-tls"]
+sync = []
+async = ["dep:tokio"]

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 use super::Error;
 use crate::error::JsonDecodeError;
 use crate::types::*;
+use crate::util::*;
 
 /// Asynchronous client for the crates.io API.
 #[derive(Clone)]
@@ -389,78 +390,6 @@ impl Client {
         let url = self.base_url.join(&format!("users/{}", username)).unwrap();
         self.get::<UserResponse>(&url).await.map(|res| res.user)
     }
-}
-
-pub(crate) fn build_crate_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    let mut url = base.join("crates")?;
-    url.path_segments_mut().unwrap().push(crate_name);
-
-    // Guard against slashes in the crate name.
-    // The API returns a nonsensical error in this case.
-    if crate_name.contains('/') {
-        Err(Error::NotFound(crate::error::NotFoundError {
-            url: url.to_string(),
-        }))
-    } else {
-        Ok(url)
-    }
-}
-
-fn build_crate_url_nested(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    let mut url = base.join("crates")?;
-    url.path_segments_mut().unwrap().push(crate_name).push("/");
-
-    // Guard against slashes in the crate name.
-    // The API returns a nonsensical error in this case.
-    if crate_name.contains('/') {
-        Err(Error::NotFound(crate::error::NotFoundError {
-            url: url.to_string(),
-        }))
-    } else {
-        Ok(url)
-    }
-}
-
-pub(crate) fn build_crate_downloads_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join("downloads")
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_owners_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join("owners")
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_reverse_deps_url(
-    base: &Url,
-    crate_name: &str,
-    page: u64,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("reverse_dependencies?per_page=100&page={page}"))
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_authors_url(
-    base: &Url,
-    crate_name: &str,
-    version: &str,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("{version}/authors"))
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_dependencies_url(
-    base: &Url,
-    crate_name: &str,
-    version: &str,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("{version}/dependencies"))
-        .map_err(Error::from)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,20 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # WASM
+//! When compiling for `WASM`, one has to disable default features and use the `async` and
+//! `reqwest/default-tls` features.
+//! ```bash
+//! cargo build\
+//!     --target wasm32-unknown-unknown\
+//!     --no-default-features\
+//!     --features async,reqwest/rustls-tls
+//! ```
+//!
+//! # Features
+//! - `sync` Enables the synchronos protocol
+//! - `async` Enables asynchronos functionality
 
 #![recursion_limit = "128"]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod async_client;
 mod error;
 mod sync_client;
 mod types;
+mod util;
 
 pub use crate::{
     async_client::Client as AsyncClient,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //!
 //! Print the most downloaded crates and their non-optional dependencies:
 //!
+#![cfg(feature = "sync")]
 //! ```rust
 //! use crates_io_api::{SyncClient, Error};
 //!
@@ -43,16 +44,26 @@
 
 #![recursion_limit = "128"]
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 mod async_client;
 mod error;
+
+#[cfg(all(feature = "sync", not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
 mod sync_client;
+
 mod types;
 mod util;
 
+#[cfg(feature = "async")]
+pub use crate::async_client::Client as AsyncClient;
+#[cfg(all(feature = "sync", not(target_arch = "wasm32")))]
+pub use crate::sync_client::SyncClient;
+
 pub use crate::{
-    async_client::Client as AsyncClient,
     error::{Error, NotFoundError, PermissionDeniedError},
-    sync_client::SyncClient,
     types::*,
 };

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -1,7 +1,8 @@
 use super::*;
 use std::iter::Extend;
 
-use reqwest::{blocking::Client as HttpClient, header, StatusCode, Url};
+use reqwest::blocking::Client as HttpClient;
+use reqwest::{header, StatusCode, Url};
 use serde::de::DeserializeOwned;
 
 use crate::{error::JsonDecodeError, types::*};

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -113,19 +113,19 @@ impl SyncClient {
     ///
     /// If you require detailed information, consider using [full_crate]().
     pub fn get_crate(&self, crate_name: &str) -> Result<CrateResponse, Error> {
-        let url = super::async_client::build_crate_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_url(&self.base_url, crate_name)?;
         self.get(url)
     }
 
     /// Retrieve download stats for a crate.
     pub fn crate_downloads(&self, crate_name: &str) -> Result<CrateDownloads, Error> {
-        let url = super::async_client::build_crate_downloads_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_downloads_url(&self.base_url, crate_name)?;
         self.get(url)
     }
 
     /// Retrieve the owners of a crate.
     pub fn crate_owners(&self, crate_name: &str) -> Result<Vec<User>, Error> {
-        let url = super::async_client::build_crate_owners_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_owners_url(&self.base_url, crate_name)?;
         let resp: Owners = self.get(url)?;
         Ok(resp.users)
     }
@@ -138,8 +138,7 @@ impl SyncClient {
         crate_name: &str,
         page: u64,
     ) -> Result<ReverseDependencies, Error> {
-        let url =
-            super::async_client::build_crate_reverse_deps_url(&self.base_url, crate_name, page)?;
+        let url = super::util::build_crate_reverse_deps_url(&self.base_url, crate_name, page)?;
         let page = self.get::<ReverseDependenciesAsReceived>(url)?;
 
         let mut deps = ReverseDependencies {
@@ -185,8 +184,7 @@ impl SyncClient {
 
     /// Retrieve the authors for a crate version.
     pub fn crate_authors(&self, crate_name: &str, version: &str) -> Result<Authors, Error> {
-        let url =
-            super::async_client::build_crate_authors_url(&self.base_url, crate_name, version)?;
+        let url = super::util::build_crate_authors_url(&self.base_url, crate_name, version)?;
         let res: AuthorsResponse = self.get(url)?;
         Ok(Authors {
             names: res.meta.names,
@@ -199,8 +197,7 @@ impl SyncClient {
         crate_name: &str,
         version: &str,
     ) -> Result<Vec<Dependency>, Error> {
-        let url =
-            super::async_client::build_crate_dependencies_url(&self.base_url, crate_name, version)?;
+        let url = super::util::build_crate_dependencies_url(&self.base_url, crate_name, version)?;
         let resp: Dependencies = self.get(url)?;
         Ok(resp.dependencies)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,75 @@
+use reqwest::Url;
+
+use super::Error;
+
+pub(crate) fn build_crate_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    let mut url = base.join("crates")?;
+    url.path_segments_mut().unwrap().push(crate_name);
+
+    // Guard against slashes in the crate name.
+    // The API returns a nonsensical error in this case.
+    if crate_name.contains('/') {
+        Err(Error::NotFound(crate::error::NotFoundError {
+            url: url.to_string(),
+        }))
+    } else {
+        Ok(url)
+    }
+}
+
+fn build_crate_url_nested(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    let mut url = base.join("crates")?;
+    url.path_segments_mut().unwrap().push(crate_name).push("/");
+
+    // Guard against slashes in the crate name.
+    // The API returns a nonsensical error in this case.
+    if crate_name.contains('/') {
+        Err(Error::NotFound(crate::error::NotFoundError {
+            url: url.to_string(),
+        }))
+    } else {
+        Ok(url)
+    }
+}
+
+pub(crate) fn build_crate_downloads_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join("downloads")
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_owners_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join("owners")
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_reverse_deps_url(
+    base: &Url,
+    crate_name: &str,
+    page: u64,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("reverse_dependencies?per_page=100&page={page}"))
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_authors_url(
+    base: &Url,
+    crate_name: &str,
+    version: &str,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("{version}/authors"))
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_dependencies_url(
+    base: &Url,
+    crate_name: &str,
+    version: &str,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("{version}/dependencies"))
+        .map_err(Error::from)
+}


### PR DESCRIPTION
This PR consists of 3 different things:
1. A refactor of existing code, adding the `util.rs` file
2. Introduction of the features `sync` and `async`
3. Loosening of dependencies.

These points above plus some very small added details allow us to use this crate within a wasm context. I tested using the following command:
```
cargo build\
    --target wasm32-unknown-unknown\
    --no-default-features\
    --features async,reqwest/rustls-tls
```