### PR TITLE
Add WASM Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = [ "crates", "api" ]
 categories = [ "web-programming", "web-programming::http-client" ]
 edition = "2018"
+resolver = "2"
 
 version = "0.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ edition = "2018"
 version = "0.11.0"
 
 [dependencies]
-chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
-serde = "1.0.79"
-serde_derive = "1.0.79"
-serde_json = "1.0.32"
-url = "2.1.0"
-futures = "0.3.4"
-tokio = { version = "1.0.1", default-features = false, features = ["sync", "time"] }
-serde_path_to_error = "0.1.8"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+url = "2.5"
+futures = "0.3"
+tokio = { version = "1.43", default-features = false, features = ["sync", "time"] }
+serde_path_to_error = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.0.1", features = ["macros"]}
+tokio = { version = "1.43", features = ["macros"]}
 
 [features]
 default = ["reqwest/default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ url = "2.5"
 futures = "0.3"
 tokio = { version = "1.43", default-features = false, features = ["sync", "time"] }
 serde_path_to_error = "0.1"
+web-time = { version = "1.1" }
 
 [dev-dependencies]
 tokio = { version = "1.43", features = ["macros"]}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -26,6 +26,7 @@ pub struct Client {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 pub struct CrateStream {
     client: Client,
     filter: CratesQuery,
@@ -36,6 +37,7 @@ pub struct CrateStream {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 impl CrateStream {
     fn new(client: Client, filter: CratesQuery) -> Self {
         Self {
@@ -49,6 +51,7 @@ impl CrateStream {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 impl futures::stream::Stream for CrateStream {
     type Item = Result<Crate, Error>;
 
@@ -391,6 +394,7 @@ impl Client {
 
     /// Get a stream over all crates matching the given [`CratesQuery`].
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
     pub fn crates_stream(&self, filter: CratesQuery) -> CrateStream {
         CrateStream::new(self.clone(), filter)
     }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 use super::Error;
 use crate::error::JsonDecodeError;
 use crate::types::*;
+use crate::util::*;
 
 /// Asynchronous client for the crates.io API.
 #[derive(Clone)]
@@ -389,78 +390,6 @@ impl Client {
         let url = self.base_url.join(&format!("users/{}", username)).unwrap();
         self.get::<UserResponse>(&url).await.map(|res| res.user)
     }
-}
-
-pub(crate) fn build_crate_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    let mut url = base.join("crates")?;
-    url.path_segments_mut().unwrap().push(crate_name);
-
-    // Guard against slashes in the crate name.
-    // The API returns a nonsensical error in this case.
-    if crate_name.contains('/') {
-        Err(Error::NotFound(crate::error::NotFoundError {
-            url: url.to_string(),
-        }))
-    } else {
-        Ok(url)
-    }
-}
-
-fn build_crate_url_nested(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    let mut url = base.join("crates")?;
-    url.path_segments_mut().unwrap().push(crate_name).push("/");
-
-    // Guard against slashes in the crate name.
-    // The API returns a nonsensical error in this case.
-    if crate_name.contains('/') {
-        Err(Error::NotFound(crate::error::NotFoundError {
-            url: url.to_string(),
-        }))
-    } else {
-        Ok(url)
-    }
-}
-
-pub(crate) fn build_crate_downloads_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join("downloads")
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_owners_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join("owners")
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_reverse_deps_url(
-    base: &Url,
-    crate_name: &str,
-    page: u64,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("reverse_dependencies?per_page=100&page={page}"))
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_authors_url(
-    base: &Url,
-    crate_name: &str,
-    version: &str,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("{version}/authors"))
-        .map_err(Error::from)
-}
-
-pub(crate) fn build_crate_dependencies_url(
-    base: &Url,
-    crate_name: &str,
-    version: &str,
-) -> Result<Url, Error> {
-    build_crate_url_nested(base, crate_name)?
-        .join(&format!("{version}/dependencies"))
-        .map_err(Error::from)
 }
 
 #[cfg(test)]

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,9 +1,12 @@
+#[cfg(not(target_arch = "wasm32"))]
 use futures::future::BoxFuture;
+#[cfg(not(target_arch = "wasm32"))]
 use futures::prelude::*;
 use futures::{future::try_join_all, try_join};
 use reqwest::{header, Client as HttpClient, StatusCode, Url};
 use serde::de::DeserializeOwned;
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::VecDeque;
 
 use web_time::Duration;
@@ -22,6 +25,7 @@ pub struct Client {
     base_url: Url,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub struct CrateStream {
     client: Client,
     filter: CratesQuery,
@@ -31,6 +35,7 @@ pub struct CrateStream {
     next_page_fetch: Option<BoxFuture<'static, Result<CratesPage, Error>>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl CrateStream {
     fn new(client: Client, filter: CratesQuery) -> Self {
         Self {
@@ -43,6 +48,7 @@ impl CrateStream {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl futures::stream::Stream for CrateStream {
     type Item = Result<Crate, Error>;
 
@@ -384,6 +390,7 @@ impl Client {
     }
 
     /// Get a stream over all crates matching the given [`CratesQuery`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn crates_stream(&self, filter: CratesQuery) -> CrateStream {
         CrateStream::new(self.clone(), filter)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 
 mod async_client;
 mod error;
+#[cfg(not(target_arch = "wasm32"))]
 mod sync_client;
 mod types;
 mod util;
@@ -53,6 +54,8 @@ mod util;
 pub use crate::{
     async_client::Client as AsyncClient,
     error::{Error, NotFoundError, PermissionDeniedError},
-    sync_client::SyncClient,
     types::*,
 };
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::sync_client::SyncClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod async_client;
 mod error;
 mod sync_client;
 mod types;
+mod util;
 
 pub use crate::{
     async_client::Client as AsyncClient,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,12 @@
 
 #![recursion_limit = "128"]
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod async_client;
 mod error;
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 mod sync_client;
 mod types;
 mod util;
@@ -58,4 +60,5 @@ pub use crate::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
 pub use crate::sync_client::SyncClient;

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -113,19 +113,19 @@ impl SyncClient {
     ///
     /// If you require detailed information, consider using [full_crate]().
     pub fn get_crate(&self, crate_name: &str) -> Result<CrateResponse, Error> {
-        let url = super::async_client::build_crate_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_url(&self.base_url, crate_name)?;
         self.get(url)
     }
 
     /// Retrieve download stats for a crate.
     pub fn crate_downloads(&self, crate_name: &str) -> Result<CrateDownloads, Error> {
-        let url = super::async_client::build_crate_downloads_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_downloads_url(&self.base_url, crate_name)?;
         self.get(url)
     }
 
     /// Retrieve the owners of a crate.
     pub fn crate_owners(&self, crate_name: &str) -> Result<Vec<User>, Error> {
-        let url = super::async_client::build_crate_owners_url(&self.base_url, crate_name)?;
+        let url = super::util::build_crate_owners_url(&self.base_url, crate_name)?;
         let resp: Owners = self.get(url)?;
         Ok(resp.users)
     }
@@ -138,8 +138,7 @@ impl SyncClient {
         crate_name: &str,
         page: u64,
     ) -> Result<ReverseDependencies, Error> {
-        let url =
-            super::async_client::build_crate_reverse_deps_url(&self.base_url, crate_name, page)?;
+        let url = super::util::build_crate_reverse_deps_url(&self.base_url, crate_name, page)?;
         let page = self.get::<ReverseDependenciesAsReceived>(url)?;
 
         let mut deps = ReverseDependencies {
@@ -185,8 +184,7 @@ impl SyncClient {
 
     /// Retrieve the authors for a crate version.
     pub fn crate_authors(&self, crate_name: &str, version: &str) -> Result<Authors, Error> {
-        let url =
-            super::async_client::build_crate_authors_url(&self.base_url, crate_name, version)?;
+        let url = super::util::build_crate_authors_url(&self.base_url, crate_name, version)?;
         let res: AuthorsResponse = self.get(url)?;
         Ok(Authors {
             names: res.meta.names,
@@ -199,8 +197,7 @@ impl SyncClient {
         crate_name: &str,
         version: &str,
     ) -> Result<Vec<Dependency>, Error> {
-        let url =
-            super::async_client::build_crate_dependencies_url(&self.base_url, crate_name, version)?;
+        let url = super::util::build_crate_dependencies_url(&self.base_url, crate_name, version)?;
         let resp: Dependencies = self.get(url)?;
         Ok(resp.dependencies)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,75 @@
+use reqwest::Url;
+
+use super::Error;
+
+pub(crate) fn build_crate_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    let mut url = base.join("crates")?;
+    url.path_segments_mut().unwrap().push(crate_name);
+
+    // Guard against slashes in the crate name.
+    // The API returns a nonsensical error in this case.
+    if crate_name.contains('/') {
+        Err(Error::NotFound(crate::error::NotFoundError {
+            url: url.to_string(),
+        }))
+    } else {
+        Ok(url)
+    }
+}
+
+fn build_crate_url_nested(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    let mut url = base.join("crates")?;
+    url.path_segments_mut().unwrap().push(crate_name).push("/");
+
+    // Guard against slashes in the crate name.
+    // The API returns a nonsensical error in this case.
+    if crate_name.contains('/') {
+        Err(Error::NotFound(crate::error::NotFoundError {
+            url: url.to_string(),
+        }))
+    } else {
+        Ok(url)
+    }
+}
+
+pub(crate) fn build_crate_downloads_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join("downloads")
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_owners_url(base: &Url, crate_name: &str) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join("owners")
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_reverse_deps_url(
+    base: &Url,
+    crate_name: &str,
+    page: u64,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("reverse_dependencies?per_page=100&page={page}"))
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_authors_url(
+    base: &Url,
+    crate_name: &str,
+    version: &str,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("{version}/authors"))
+        .map_err(Error::from)
+}
+
+pub(crate) fn build_crate_dependencies_url(
+    base: &Url,
+    crate_name: &str,
+    version: &str,
+) -> Result<Url, Error> {
+    build_crate_url_nested(base, crate_name)?
+        .join(&format!("{version}/dependencies"))
+        .map_err(Error::from)
+}


### PR DESCRIPTION
This PR makes the `crates_io_api` package able to be used in a WASM context. Some functionality such as `std::time` needed to be replaced with the `web_time` crate which exports `std::time` for non-wasm systems (such as `x86`). In total this PR does 3 things:
1. Refactor Code; exlude shared functionality in `utils.rs`
2. Loosen and Update Dependencies
3. Rewrite `async_client.rs` file such that it can be compiled with the `wasm32-unknown-unknown` target triple.

All tests are still passing. Users which have used this package should not be affected by any of the changes made. Let me know what you think.